### PR TITLE
fix(image-build): change from emulation to cross-compile

### DIFF
--- a/.github/workflows/migrations-docker.yml
+++ b/.github/workflows/migrations-docker.yml
@@ -61,9 +61,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1

--- a/.github/workflows/processes-worker-docker.yml
+++ b/.github/workflows/processes-worker-docker.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,9 +113,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
-
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker meta
         id: meta

--- a/.github/workflows/service-docker.yml
+++ b/.github/workflows/service-docker.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1

--- a/docker/Dockerfile-dim-migrations
+++ b/docker/Dockerfile-dim-migrations
@@ -18,9 +18,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
-
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS publish
+ARG TARGETARCH
 WORKDIR /
 COPY LICENSE /
 COPY /src/database /src/database
@@ -28,7 +27,7 @@ COPY /src/processes/Processes.Worker.Library /src/processes/Processes.Worker.Lib
 WORKDIR /src/database/Dim.Migrations
 RUN dotnet publish "Dim.Migrations.csproj" -c Release -o /migrations/publish
 
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /migrations
 COPY --from=publish /migrations/publish .

--- a/docker/Dockerfile-dim-processes-worker
+++ b/docker/Dockerfile-dim-processes-worker
@@ -18,9 +18,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
-
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS publish
+ARG TARGETARCH
 WORKDIR /
 COPY LICENSE /
 COPY src/ src/
@@ -28,7 +27,7 @@ RUN dotnet restore "src/processes/Processes.Worker/Processes.Worker.csproj"
 WORKDIR /src/processes/Processes.Worker
 RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish
 
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/docker/Dockerfile-dim-service
+++ b/docker/Dockerfile-dim-service
@@ -18,20 +18,20 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
-
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS publish
+ARG TARGETARCH
 WORKDIR /
 COPY LICENSE /
 COPY src/ src/
 WORKDIR /src/web/Dim.Web
 RUN dotnet publish "Dim.Web.csproj" -c Release -o /app/publish
 
-FROM base AS final
-ENV COMPlus_EnableDiagnostics=0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+ENV \
+    COMPlus_EnableDiagnostics=0 \
+    ASPNETCORE_URLS=http://+:8080
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENV ASPNETCORE_URLS http://+:8080
 EXPOSE 8080
 RUN chown -R 1000:3000 /app
 USER 1000:3000


### PR DESCRIPTION
## Description

- change from emulation to cross-compile for building multi-platform images
- also, improve dockerfiles by removing unnecessary base stage and aligning environment variables

## Why

https://github.com/eclipse-tractusx/portal-backend/issues/802
https://docs.docker.com/build/building/multi-platform
https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support

## Checklist

- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes