### PR TITLE
chore(dependencies): bump efcore to 8.0.7

### DIFF
--- a/src/clients/Dim.Clients/Dim.Clients.csproj
+++ b/src/clients/Dim.Clients/Dim.Clients.csproj
@@ -33,12 +33,11 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.4.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.4.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions" Version="2.4.2" />
     </ItemGroup>
 
 </Project>

--- a/src/database/Dim.DbAccess/Dim.DbAccess.csproj
+++ b/src/database/Dim.DbAccess/Dim.DbAccess.csproj
@@ -29,9 +29,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.3" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.4.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/database/Dim.Entities/Dim.Entities.csproj
+++ b/src/database/Dim.Entities/Dim.Entities.csproj
@@ -29,11 +29,11 @@
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="2.4.2" />
     </ItemGroup>
 </Project>

--- a/src/database/Dim.Migrations/Dim.Migrations.csproj
+++ b/src/database/Dim.Migrations/Dim.Migrations.csproj
@@ -36,7 +36,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -44,10 +44,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.4.2" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.4.2" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/processes/DimProcess.Library/DimProcess.Library.csproj
+++ b/src/processes/DimProcess.Library/DimProcess.Library.csproj
@@ -32,8 +32,8 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.4.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/processes/Processes.Worker.Library/Processes.Worker.Library.csproj
+++ b/src/processes/Processes.Worker.Library/Processes.Worker.Library.csproj
@@ -32,9 +32,9 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Async" Version="2.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Async" Version="2.4.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.4.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.4.2" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/processes/Processes.Worker/Processes.Worker.csproj
+++ b/src/processes/Processes.Worker/Processes.Worker.csproj
@@ -41,7 +41,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/web/Dim.Web/Dim.Web.csproj
+++ b/src/web/Dim.Web/Dim.Web.csproj
@@ -14,8 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.3.0"/>
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.4.2"/>
         <PackageReference Include="System.Json" Version="4.7.1" />
     </ItemGroup>
 

--- a/tests/processes/DimProcess.Library.Tests/DimProcessHandlerTests.cs
+++ b/tests/processes/DimProcess.Library.Tests/DimProcessHandlerTests.cs
@@ -34,7 +34,6 @@ using DimProcess.Library.Callback;
 using DimProcess.Library.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 namespace DimProcess.Library.Tests;

--- a/tests/shared/Tests.Shared/Tests.Shared.csproj
+++ b/tests/shared/Tests.Shared/Tests.Shared.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
+    <PackageReference Include="Testcontainers" Version="3.9.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

increase framework version to latest 2.4.2
increase efcore version to latest 8.0.7
increase testcontainers version to 3.9.0

## Why

efcore 8.0.3 has transitive dependency System.Text.Json 8.0.0 which has a security-vulerability that is clasified as high. Upgrade to efcore 8.0.7 implicitly upgrades this dependency to System.Text.Json 8.0.4.
same applies to framework and testcontainers, both were referring outdated System.Text.Json which is implicitly resolved by referencing the respective latest versions.

## Issue

https://github.com/eclipse-tractusx/portal/issues/369

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
