### PR TITLE
fix(tenantName): remove invalid characters from tenant name

### DIFF
--- a/src/clients/Dim.Clients/Api/SubAccounts/ISubAccountClient.cs
+++ b/src/clients/Dim.Clients/Api/SubAccounts/ISubAccountClient.cs
@@ -24,7 +24,7 @@ namespace Dim.Clients.Api.SubAccounts;
 
 public interface ISubAccountClient
 {
-    Task<Guid> CreateSubaccount(BasicAuthSettings basicAuthSettings, string adminMail, string tenantName, Guid directoryId, CancellationToken cancellationToken);
+    Task<Guid> CreateSubaccount(BasicAuthSettings basicAuthSettings, string adminMail, string tenantName, Guid directoryId, string bpn, CancellationToken cancellationToken);
     Task CreateServiceManagerBindings(BasicAuthSettings basicAuthSettings, Guid subAccountId, CancellationToken cancellationToken);
     Task<ServiceManagementBindingItem> GetServiceManagerBindings(BasicAuthSettings basicAuthSettings, Guid subAccountId, CancellationToken cancellationToken);
 }

--- a/src/database/Dim.DbAccess/Repositories/ITenantRepository.cs
+++ b/src/database/Dim.DbAccess/Repositories/ITenantRepository.cs
@@ -19,6 +19,8 @@
  ********************************************************************************/
 
 using Dim.Entities.Entities;
+using System;
+using System.Threading.Tasks;
 
 namespace Dim.DbAccess.Repositories;
 
@@ -47,4 +49,5 @@ public interface ITenantRepository
     Task<Guid> GetExternalIdForTechnicalUser(Guid technicalUserId);
     void RemoveTechnicalUser(Guid technicalUserId);
     Task<bool> IsTenantExisting(string companyName, string bpn);
+    Task<string> GetTenantBpn(Guid tenantId);
 }

--- a/src/database/Dim.DbAccess/Repositories/TenantRepository.cs
+++ b/src/database/Dim.DbAccess/Repositories/TenantRepository.cs
@@ -21,6 +21,8 @@
 using Dim.Entities;
 using Dim.Entities.Entities;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
 
 namespace Dim.DbAccess.Repositories;
 
@@ -165,4 +167,10 @@ public class TenantRepository(DimDbContext context) : ITenantRepository
     public Task<bool> IsTenantExisting(string companyName, string bpn) =>
         context.Tenants
             .AnyAsync(x => x.CompanyName == companyName && x.Bpn == bpn);
+
+    public Task<string> GetTenantBpn(Guid tenantId) =>
+        context.Tenants
+            .Where(x => x.Id == tenantId)
+            .Select(x => x.Bpn)
+            .SingleAsync();
 }

--- a/src/processes/DimProcess.Library/DimProcessHandler.cs
+++ b/src/processes/DimProcess.Library/DimProcessHandler.cs
@@ -62,7 +62,8 @@ public class DimProcessHandler(
             ClientSecret = _settings.ClientsecretCisCentral
         };
 
-        var subAccountId = await subAccountClient.CreateSubaccount(subAccountAuth, adminMail, tenantName, parentDirectoryId, cancellationToken).ConfigureAwait(false);
+        var bpn = await dimRepositories.GetInstance<ITenantRepository>().GetTenantBpn(tenantId);
+        var subAccountId = await subAccountClient.CreateSubaccount(subAccountAuth, adminMail, tenantName, parentDirectoryId, bpn, cancellationToken).ConfigureAwait(false);
         dimRepositories.GetInstance<ITenantRepository>().AttachAndModifyTenant(tenantId, tenant =>
             {
                 tenant.SubAccountId = null;

--- a/tests/processes/DimProcess.Library.Tests/DimProcessHandlerTests.cs
+++ b/tests/processes/DimProcess.Library.Tests/DimProcessHandlerTests.cs
@@ -109,7 +109,7 @@ public class DimProcessHandlerTests
                 initialize?.Invoke(tenant);
                 modify(tenant);
             });
-        A.CallTo(() => _subAccountClient.CreateSubaccount(A<BasicAuthSettings>._, A<string>._, _tenantName, A<Guid>._, A<CancellationToken>._))
+        A.CallTo(() => _subAccountClient.CreateSubaccount(A<BasicAuthSettings>._, A<string>._, _tenantName, A<Guid>._, A<string>._, A<CancellationToken>._))
             .Returns(subAccountId);
 
         // Act

--- a/tests/web/Dim.Web.Tests/DimBusinessLogicTests.cs
+++ b/tests/web/Dim.Web.Tests/DimBusinessLogicTests.cs
@@ -77,8 +77,14 @@ public class DimBusinessLogicTests
         result.Message.Should().Be($"Tenant testCompany with Bpn BPNL00000001TEST already exists");
     }
 
-    [Fact]
-    public async Task StartSetupDim_WithNewData_CreatesExpected()
+    [Theory]
+    [InlineData("testCompany", "testcompany")]
+    [InlineData("-abc123", "abc123")]
+    [InlineData("abc-123", "abc123")]
+    [InlineData("abc#123", "abc123")]
+    [InlineData("abc'123", "abc123")]
+    [InlineData("abc\"123", "abc123")]
+    public async Task StartSetupDim_WithNewData_CreatesExpected(string companyName, string expectedCompanyName)
     {
         // Arrange
         var processId = Guid.NewGuid();
@@ -106,7 +112,7 @@ public class DimBusinessLogicTests
             });
 
         // Act
-        await _sut.StartSetupDim("testCompany", "BPNL00000001TEST", "https://example.org/test", false);
+        await _sut.StartSetupDim(companyName, "BPNL00000001TEST", "https://example.org/test", false);
 
         // Assert
         processes.Should().ContainSingle()
@@ -114,6 +120,6 @@ public class DimBusinessLogicTests
         processSteps.Should().ContainSingle()
             .And.Satisfy(x => x.ProcessId == processId && x.ProcessStepTypeId == ProcessStepTypeId.CREATE_SUBACCOUNT);
         tenants.Should().ContainSingle()
-            .And.Satisfy(x => x.CompanyName == "testCompany" && x.Bpn == "BPNL00000001TEST");
+            .And.Satisfy(x => x.CompanyName == expectedCompanyName && x.Bpn == "BPNL00000001TEST");
     }
 }


### PR DESCRIPTION
## Description

* check for invalid characters in company name when creating the tenant, if existing remove those.
* use only the bpn for the the subdomain when creating the subAccount

## Why

The sap wallet only accepts letters, digits and hyphens (not at the start or end)

## Issue

Refs: #86 #87

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
