### PR TITLE
fix(environment): adjust getEnvironment exception handling

### DIFF
--- a/src/clients/Dim.Clients/Api/Cf/CfClient.cs
+++ b/src/clients/Dim.Clients/Api/Cf/CfClient.cs
@@ -80,9 +80,9 @@ public class CfClient : ICfClient
             .ConfigureAwait(false);
 
         var tenantEnvironment = environments?.Resources.Where(x => x.Name == tenantName);
-        if (tenantEnvironment == null || tenantEnvironment.Count() > 1)
+        if (tenantEnvironment == null || tenantEnvironment.Count() != 1)
         {
-            throw new ConflictException($"There should only be one cf environment for tenant {tenantName}");
+            throw new ServiceException($"There should only be one cf environment for tenant {tenantName}", true);
         }
 
         return tenantEnvironment.Single().EnvironmentId;

--- a/src/clients/Dim.Clients/Api/Entitlements/EntitlementClient.cs
+++ b/src/clients/Dim.Clients/Api/Entitlements/EntitlementClient.cs
@@ -48,6 +48,6 @@ public class EntitlementClient : IEntitlementClient
             );
 
         await client.PutAsJsonAsync("/entitlements/v1/subaccountServicePlans", data, JsonSerializerExtensions.Options, cancellationToken)
-            .CatchingIntoServiceExceptionFor("assign-entitlements", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
+            .CatchingIntoServiceExceptionFor("assign-entitlements", HttpAsyncResponseMessageExtension.RecoverOptions.ALLWAYS).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Description

Adding error handling for getEnvironmentId to check for non existing environments

## Why

The check for tenant environments did only check for > 1 not any

## Issue

Refs: #84 #87

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
