### PR TITLE
fix: adjust name check for tenant and technical user

### DIFF
--- a/src/clients/Dim.Clients/Api/Div/Models/ServiceKeyOperationCreationRequest.cs
+++ b/src/clients/Dim.Clients/Api/Div/Models/ServiceKeyOperationCreationRequest.cs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Dim.Clients.Api.Div.Models;
@@ -30,7 +32,12 @@ public record ServiceKeyOperationCreationRequest(
 
 public record ServiceKeyCreationPayloadData(
     [property: JsonPropertyName("customerWalletId")] Guid CustomerWalletId,
-    [property: JsonPropertyName("divWalletServiceName")] string ServiceKeyName
+    [property: JsonPropertyName("divWalletServiceName")] string ServiceKeyName,
+    [property: JsonPropertyName("divWalletServiceParameters")] ServiceKeyParameter Parameter
+);
+
+public record ServiceKeyParameter(
+    [property: JsonPropertyName("authorities")] IEnumerable<string> Authorities
 );
 
 public record ServiceKeyOperationDeletionRequest(

--- a/src/clients/Dim.Clients/Api/Div/ProvisioningClient.cs
+++ b/src/clients/Dim.Clients/Api/Div/ProvisioningClient.cs
@@ -25,8 +25,12 @@ using Dim.Clients.Token;
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions;
+using System;
+using System.Linq;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Dim.Clients.Api.Div;
 
@@ -138,7 +142,8 @@ public class ProvisioningClient(IBasicAuthTokenService basicAuthTokenService, IO
             "create",
             new ServiceKeyCreationPayloadData(
                 walletId,
-                technicalUserName
+                technicalUserName,
+                new ServiceKeyParameter(new[] { "IatpOperations", "ReadCompanyIdentity", "ResolveDID" })
             )
         );
         var client = await basicAuthTokenService

--- a/src/clients/Dim.Clients/Token/IBasicAuthTokenService.cs
+++ b/src/clients/Dim.Clients/Token/IBasicAuthTokenService.cs
@@ -18,6 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Dim.Clients.Token;
 
 public interface IBasicAuthTokenService


### PR DESCRIPTION
## Description

replace all characters that are not alphabetical or numeric for technical users and tenants

## Why

The wallet creation fails when trying to create a wallet with a name longer than 32 characters and any other characters other than alphabetical or numeric

## Issue

Refs: #112

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
