### PR TITLE
feat: Migrate from Temurin 17 to SapMachine 17

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with:
-          distribution: 'temurin'
+          distribution: 'sapmachine'
           java-version: '17'
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Hi Colleagues,

[SapMachine](https://sapmachine.io/) is now available with
actions/setup-java@v4
Created a PR to migrate from Temurin 17 to SapMachine 17

Regards Christian@SapMachine Team