### PR TITLE
fix: normalize tenant and technical user names in process retrieval

### DIFF
--- a/src/web/Dim.Web/BusinessLogic/DimBusinessLogic.cs
+++ b/src/web/Dim.Web/BusinessLogic/DimBusinessLogic.cs
@@ -186,7 +186,8 @@ public class DimBusinessLogic(
 
     public async Task<ProcessData> GetSetupProcess(string bpn, string companyName)
     {
-        var processData = await dimRepositories.GetInstance<ITenantRepository>().GetWalletProcessForTenant(bpn, companyName)
+        var tenant = GetName(companyName, bpn);
+        var processData = await dimRepositories.GetInstance<ITenantRepository>().GetWalletProcessForTenant(bpn, tenant)
             .ConfigureAwait(ConfigureAwaitOptions.None);
         if (processData == null)
         {
@@ -198,7 +199,9 @@ public class DimBusinessLogic(
 
     public async Task<ProcessData> GetTechnicalUserProcess(string bpn, string companyName, string technicalUserName)
     {
-        var processData = await dimRepositories.GetInstance<ITechnicalUserRepository>().GetTechnicalUserProcess(bpn, companyName, technicalUserName)
+        var tenant = GetName(companyName, bpn);
+        var techUserName = GetName(technicalUserName, bpn);
+        var processData = await dimRepositories.GetInstance<ITechnicalUserRepository>().GetTechnicalUserProcess(bpn, tenant, techUserName)
             .ConfigureAwait(ConfigureAwaitOptions.None);
         if (processData == null)
         {


### PR DESCRIPTION
## Description

Process Retrieval Fails Due to Missing Normalization of Tenant and Technical User Names

## Why
The retrieval logic should apply the same normalization rules to companyName and technicalUserName as used during the creation phase. This will ensure consistent lookup and successful process ID retrieval.

## Issue

#187 

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
